### PR TITLE
Make the library work in the .NET 4.8 projects

### DIFF
--- a/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/App.config
+++ b/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/Properties/AssemblyInfo.cs
+++ b/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("HP")]
+[assembly: AssemblyProduct("WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8")]
+[assembly: AssemblyCopyright("Copyright © HP 2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e8fa5ea5-361e-4bb5-a026-78e6573dc3ab")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8.csproj
+++ b/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8.csproj
@@ -1,0 +1,209 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net._4._8</RootNamespace>
+    <AssemblyName>WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <LangVersion>10.0</LangVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=6.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.6.0.5\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Clear.cs">
+      <Link>Clear.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\ClearWindow.cs">
+      <Link>ClearWindow.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Close.cs">
+      <Link>Close.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Configure.cs">
+      <Link>Configure.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Decode.cs">
+      <Link>Decode.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\FreeText.cs">
+      <Link>FreeText.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\HaltTx.cs">
+      <Link>HaltTx.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Heartbeat.cs">
+      <Link>Heartbeat.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\HighlightCallsign.cs">
+      <Link>HighlightCallsign.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\IWsjtxDirectionIn.cs">
+      <Link>IWsjtxDirectionIn.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\IWsjtxDirectionOut.cs">
+      <Link>IWsjtxDirectionOut.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\KeyboardModifiers.cs">
+      <Link>KeyboardModifiers.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Location.cs">
+      <Link>Location.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\LoggedAdif.cs">
+      <Link>LoggedAdif.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\MessageType.cs">
+      <Link>MessageType.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\QColor.cs">
+      <Link>QColor.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\QColors.cs">
+      <Link>QColors.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\QColorSpec.cs">
+      <Link>QColorSpec.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\QsoLogged.cs">
+      <Link>QsoLogged.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Replay.cs">
+      <Link>Replay.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Reply.cs">
+      <Link>Reply.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\SchemaVersion.cs">
+      <Link>SchemaVersion.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\SpecialOperationMode.cs">
+      <Link>SpecialOperationMode.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Status.cs">
+      <Link>Status.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\SwitchConfiguration.cs">
+      <Link>SwitchConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\Timespec.cs">
+      <Link>Timespec.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\WsjtxMessage.cs">
+      <Link>WsjtxMessage.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\Messages\WSPRDecode.cs">
+      <Link>WSPRDecode.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\WsjtxBaseReaderWriter.cs">
+      <Link>WsjtxBaseReaderWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\WsjtxConstants.cs">
+      <Link>WsjtxConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\WsjtxMessageExtensions.cs">
+      <Link>WsjtxMessageExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\WsjtxMessageReader.cs">
+      <Link>WsjtxMessageReader.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxMessages\WsjtxMessageWriter.cs">
+      <Link>WsjtxMessageWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole\WriteMessageToConsoleAsJsonHandler.cs">
+      <Link>WriteMessageToConsoleAsJsonHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer\IWsjtxUdpMessageHandler.cs">
+      <Link>IWsjtxUdpMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer\WsjtxConnectedClient.cs">
+      <Link>WsjtxConnectedClient.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer\WsjtxUdpServer.cs">
+      <Link>WsjtxUdpServer.cs</Link>
+    </Compile>
+    <Compile Include="..\src\WsjtxUtils.WsjtxUdpServer\WsjtxUdpServerBaseAsyncMessageHandler.cs">
+      <Link>WsjtxUdpServerBaseAsyncMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets" Condition="Exists('..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets'))" />
+  </Target>
+</Project>

--- a/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/packages.config
+++ b/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="6.0.5" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+</packages>

--- a/WsjtxUtils.sln
+++ b/WsjtxUtils.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WsjtxUtils.WsjtxUdpServer.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole", "src\WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole\WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.csproj", "{5E849F16-DCF6-4D85-8735-A5D268366371}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8", "WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8\WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole.net.4.8.csproj", "{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +55,10 @@ Global
 		{5E849F16-DCF6-4D85-8735-A5D268366371}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E849F16-DCF6-4D85-8735-A5D268366371}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E849F16-DCF6-4D85-8735-A5D268366371}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8FA5EA5-361E-4BB5-A026-78E6573DC3AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WsjtxUtils.WsjtxMessages/WsjtxMessageExtensions.cs
+++ b/src/WsjtxUtils.WsjtxMessages/WsjtxMessageExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using WsjtxUtils.WsjtxMessages.Messages;
 
 namespace WsjtxUtils.WsjtxMessages

--- a/src/WsjtxUtils.WsjtxMessages/WsjtxMessageReader.cs
+++ b/src/WsjtxUtils.WsjtxMessages/WsjtxMessageReader.cs
@@ -164,7 +164,7 @@ namespace WsjtxUtils.WsjtxMessages
             if (size == 0 || size == uint.MaxValue)
                 return string.Empty;
 
-            if (MemoryMarshal.TryGetArray(buffer[Position..], out ArraySegment<byte> segment) && segment.Array != null)
+            if (MemoryMarshal.TryGetArray(buffer.Slice(Position), out ArraySegment<byte> segment) && segment.Array != null)
             {
                 var length = Convert.ToInt32(size);
                 Position += length;

--- a/src/WsjtxUtils.WsjtxMessages/WsjtxMessageWriter.cs
+++ b/src/WsjtxUtils.WsjtxMessages/WsjtxMessageWriter.cs
@@ -123,7 +123,7 @@ namespace WsjtxUtils.WsjtxMessages
             if (textByteCount == 0)
                 return;
 
-            if (!MemoryMarshal.TryGetArray(buffer[Position..], out ArraySegment<byte> segment) && segment.Array != null)
+            if (!MemoryMarshal.TryGetArray(buffer.Slice(Position), out ArraySegment<byte> segment) && segment.Array != null)
                 throw new InsufficientMemoryException("Unable to allocate the array from the underlying buffer.");
 
             Encoding.UTF8.GetBytes(value, 0, value.Length, segment.Array!, segment.Offset);

--- a/src/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole/Program.cs
+++ b/src/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
+using System.Threading;
 using WsjtxUtils.WsjtxUdpServer;
 using WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole;
 

--- a/src/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole/WriteMessageToConsoleAsJsonHandler.cs
+++ b/src/WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole/WriteMessageToConsoleAsJsonHandler.cs
@@ -1,6 +1,9 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using WsjtxUtils.WsjtxMessages.Messages;
 
 namespace WsjtxUtils.WsjtxUdpServer.Example.WriteJsonToConsole

--- a/src/WsjtxUtils.WsjtxUdpServer/WsjtxConnectedClient.cs
+++ b/src/WsjtxUtils.WsjtxUdpServer/WsjtxConnectedClient.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Net;
 using WsjtxUtils.WsjtxMessages.Messages;
 

--- a/src/WsjtxUtils.WsjtxUdpServer/WsjtxUdpServerBaseAsyncMessageHandler.cs
+++ b/src/WsjtxUtils.WsjtxUdpServer/WsjtxUdpServerBaseAsyncMessageHandler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;


### PR DESCRIPTION
I am using this excellent library in a .NET 4.8 project (because some other libraries that I use are not .NET6-ready). A few changes, included in this pull request, were required to make it compile. 

A new example, `WriteJsonToConsole.net.4.8`, is included for the testing purposes. The original library and the .NET6 example still build and work as before. Please review and see if the changes could be included in the main branch - this would allow me to include the library in my project as a GitHub submodule rather than have a modified static copy of the code.